### PR TITLE
Issue #4279 Fix case sensitive WSL2 validation check

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -36,7 +36,7 @@ func checkRunningInsideWSL2() error {
 		return err
 	}
 
-	if strings.Contains(string(version), "Microsoft") {
+	if strings.Contains(strings.ToLower(string(version)), "microsoft") {
 		logging.Debugf("Running inside WSL2 environment")
 		return fmt.Errorf("CRC is unsupported using WSL2")
 	}


### PR DESCRIPTION

**Fixes:** Issue #4279

**Relates to:** Issue #2131, PR #2323

## Solution/Idea

Enhancing WSL validation check to be case-insensitive to prevent users from attempting to run on an unsupported platform.

## Proposed changes

Updated validation check to force `toLower(...)` on the output of `/proc/version` prior to searching for the target substring of `microsoft`.

## Testing

Validation check now prevents running on systems running WSL regardless of the capitalization of the word `Microsoft`.

```shell
alegacy@localhost:~/src/go/github.com/crc$ ./out/crc setup
INFO Using bundle path /home/alegacy/.crc/cache/crc_libvirt_0.0.0-unset_amd64.crcbundle 
INFO Checking if running as non-root              
INFO Checking if running inside WSL2              
CRC is unsupported using WSL2

alegacy@localhost:~/src/go/github.com/crc$ cat /proc/version
Linux version 5.15.153.1-microsoft-standard-WSL2 (root@941d701f84f1) (gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.37) #1 SMP Fri Mar 29 23:14:13 UTC 2024
```